### PR TITLE
Add version option config and use branch without changes

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -115,16 +115,18 @@ Config.prototype.getProjectRef = function (projectName) {
     return 'refs/tags/' + tag
   }
 
+  let version = getNPMConfig(['projects', projectName, 'version'])
   let branch = getNPMConfig(['projects', projectName, 'branch'])
-  if (!branch) {
+  if (!branch && !version) {
     if (projectName === 'node') {
       return null
-    } else {
-      return 'origin/master'
     }
-  } else {
-    branch = `origin/${branch}`
+    return 'origin/master'
   }
+  if (!version) {
+    return `origin/${branch}`
+  }
+  branch = `origin/${version}`
 
   if (projectName === 'muon') {
     const chromeVersion = getProjectVersion('chrome')
@@ -132,14 +134,6 @@ Config.prototype.getProjectRef = function (projectName) {
       branch = `${branch}+${chromeVersion}`
     }
   }
-
-  if (projectName === 'browser_laptop') {
-    const muonVersion = getProjectVersion('muon')
-    if (muonVersion) {
-      branch = `${branch}`
-    }
-  }
-
   return branch
 }
 


### PR DESCRIPTION
This makes version work like the branch option used to, and makes branch so it is used explicitly

Fix #17