### PR TITLE
Fix linux rsync command

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "publish": "node ./scripts/commands.js publish",
     "start": "node ./scripts/commands.js start",
     "rsync-prebuilt": "rsync -avz --delete src/out/Release/Brave.app/ src/browser-laptop/node_modules/electron-prebuilt/dist/Brave.app/",
-    "rsync-prebuilt-linux": "rsync -avz --delete src/out/Release/dist src/browser-laptop/node_modules/electron-prebuilt/dist/",
+    "rsync-prebuilt-linux": "rsync -avz --delete src/out/Release/dist/ src/browser-laptop/node_modules/electron-prebuilt/dist/",
     "xcopy-prebuilt": "xcopy src\\out\\Release\\dist src\\browser-laptop\\node_modules\\electron-prebuilt\\dist\\ /Y /S /I /F /R",
     "unittest": "NODE_ENV=test src/browser-laptop/node_modules/.bin/mocha --require babel-register --require babel-polyfill 'src/browser-laptop/test/unit/**/*Test.js'"
   },


### PR DESCRIPTION
Add trailing slash so it doesn't create an extra 'dist/' subdirectory inside 'electron-prebuilt/dist/'