### PR TITLE
Give preference to depot_tools in src/third_party/ over vendor/

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -210,6 +210,7 @@ Config.prototype.update = function (options) {
 Object.defineProperty(Config.prototype, 'defaultOptions', {
   get: function () {
     let env = Object.assign({}, process.env)
+    env = this.addPathToEnv(env, path.join(this.srcDir, 'third_party', 'depot_tools'))
     env = this.addPathToEnv(env, this.depotToolsDir)
     env.GCLIENT_FILE = this.gClientFile
     env.DEPOT_TOOLS_WIN_TOOLCHAIN = '0'


### PR DESCRIPTION
This fixes some errors when the version of depot_tools is too old and some checked out files conflict with the new auto-updated version.