### PR TITLE
Make DCHECK log a message instead of crashing

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -60,6 +60,7 @@ Config.prototype.buildArgs = function () {
     is_official_build: this.officialBuild,
     is_debug: this.buildConfig !== 'Release',
     dcheck_always_on: this.buildConfig !== 'Release',
+    dcheck_is_configurable: this.buildConfig !== 'Release',
     google_api_key: this.googleApiKey,
     electron_google_api_key: this.geoApiKey,
     electron_google_api_endpoint: this.geoApiEndpoint,
@@ -78,6 +79,7 @@ Config.prototype.buildArgs = function () {
     args.enable_profiling = true
     args.is_win_fastlink = true
     args.is_debug = true
+    args.dcheck_is_configurable: true,
   }
 
   let sccache = getNPMConfig(['sccache'])


### PR DESCRIPTION
This allows to launch debug builds without crashing the browser.