### PR TITLE
set disable_ftp_support buildflag to true

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -56,6 +56,7 @@ Config.prototype.buildArgs = function () {
     enable_supervised_users: false,
     branding_path_component: "brave",
     enable_widevine: process.platform !== 'linux',
+    disable_ftp_support: true,
     target_cpu: this.targetArch,
     is_official_build: this.officialBuild,
     is_debug: this.buildConfig !== 'Release',


### PR DESCRIPTION
part of https://github.com/brave/browser-laptop/issues/14712

depends on https://github.com/brave/muon/pull/633